### PR TITLE
Fixed Memory Leak

### DIFF
--- a/src/aditof_utils.cpp
+++ b/src/aditof_utils.cpp
@@ -298,8 +298,6 @@ void getNewFrame(const std::shared_ptr<Camera> &camera, aditof::Frame **frame) {
 uint16_t *getFrameData(aditof::Frame **frame, const std::string &dataType) {
     uint16_t *frameData;
     Status status = Status::OK;
-    aditof::Frame *test;
-    test = new Frame;
 
     status = (*frame)->getData(dataType, &frameData);
 


### PR DESCRIPTION
In getFrameData function, the memory gets allocated for frame using the following code:

```
aditof::Frame *test;
test = new Frame;
```

The variable test is not being used anywhere and also the allocated memory is getting leaked.

Fix: Remove the code as it is not required.